### PR TITLE
Fixed can use command on dying

### DIFF
--- a/src/main/java/com/creativemd/playerrevive/gui/SubGuiRevive.java
+++ b/src/main/java/com/creativemd/playerrevive/gui/SubGuiRevive.java
@@ -72,7 +72,7 @@ public class SubGuiRevive extends SubGui {
 				public void onClicked(int x, int y, int button) {
 					GuiTextfield chat = (GuiTextfield) SubGuiRevive.this.get("chat");
 					
-					if (!chat.text.equals("")) {
+					if (!chat.text.equals("")&&!chat.text.startsWith("/")) {
 						gui.sendChatMessage(chat.text);
 						
 						chat.setSelectionPos(0);
@@ -109,7 +109,7 @@ public class SubGuiRevive extends SubGui {
 		if (!((SubContainerRevive) container).isHelping && key == org.lwjgl.input.Keyboard.KEY_RETURN) {
 			GuiTextfield chat = (GuiTextfield) SubGuiRevive.this.get("chat");
 			
-			if (!chat.text.equals("")) {
+			if (!chat.text.equals("")&&!chat.text.startsWith("/")) {
 				gui.sendChatMessage(chat.text);
 				
 				chat.setSelectionPos(0);


### PR DESCRIPTION
Hello CreativeMD  
I see player can use command teleport their body on dying status, can i disable they use command in dying?   
(my english is very poor, this is google translate)