### PR TITLE
Improved translations and cleaned up their files

### DIFF
--- a/src/main/java/team/creative/playerrevive/PlayerReviveConfig.java
+++ b/src/main/java/team/creative/playerrevive/PlayerReviveConfig.java
@@ -72,6 +72,7 @@ public class PlayerReviveConfig {
         
         @CreativeConfig
         public boolean bleedingMessage = true;
+        
         @CreativeConfig
         public boolean bleedingMessageTrackingOnly = true;
         

--- a/src/main/java/team/creative/playerrevive/server/ReviveEventServer.java
+++ b/src/main/java/team/creative/playerrevive/server/ReviveEventServer.java
@@ -92,7 +92,7 @@ public class ReviveEventServer {
                             revive.setItemConsumed();
                         } else {
                             if (!helper.level().isClientSide)
-                                helper.sendSystemMessage(Component.translatable("playerrevive.revive.item").append(PlayerRevive.CONFIG.revive.reviveItem.description()));
+                                helper.sendSystemMessage(Component.translatable("playerrevive.revive.item", PlayerRevive.CONFIG.revive.reviveItem.description()));
                             return;
                         }
                     } else if (!PlayerRevive.CONFIG.revive.reviveItem.is(helper.getMainHandItem()))
@@ -194,18 +194,16 @@ public class ReviveEventServer {
                 
                 if (PlayerRevive.CONFIG.bleeding.affectHunger)
                     player.getFoodData().setFoodLevel(PlayerRevive.CONFIG.bleeding.remainingHunger);
+                
                 player.setHealth(PlayerRevive.CONFIG.bleeding.bleedingHealth);
                 
                 if (PlayerRevive.CONFIG.bleeding.bleedingMessage)
                     if (PlayerRevive.CONFIG.bleeding.bleedingMessageTrackingOnly) {
                         if (player.level().getChunkSource() instanceof ServerChunkCache chunkCache)
-                            chunkCache.broadcastAndSend(player, new ClientboundSystemChatPacket(Component.translatable("playerrevive.chat.bleeding", player.getDisplayName(), player
-                                    .getCombatTracker().getDeathMessage()), false));
+                            chunkCache.broadcastAndSend(player, new ClientboundSystemChatPacket(Component.translatable("playerrevive.chat.bleeding", player.getDisplayName()), false));
                     } else
-                        player.getServer().getPlayerList().broadcastSystemMessage(Component.translatable("playerrevive.chat.bleeding", player.getDisplayName(), player
-                                .getCombatTracker().getDeathMessage()), false);
+                        player.getServer().getPlayerList().broadcastSystemMessage(Component.translatable("playerrevive.chat.bleeding", player.getDisplayName()), false);
             }
         }
     }
-    
 }

--- a/src/main/resources/assets/playerrevive/lang/cs_cz.json
+++ b/src/main/resources/assets/playerrevive/lang/cs_cz.json
@@ -1,7 +1,5 @@
 {
-	"playerrevive.chat.bleeding": "%s krvácí...",
-	"death.attack.bledToDeath.player": "%s vykrvácel",
-	"playerrevive.gui.button.send": "poslat",
-	"playerrevive.gui.label.time_left": "Zbývající čas %s",
-	"playerrevive.gui.hold": "Drž '%s' po dobu %s sekund"
+  "playerrevive.chat.bleeding": "%s krvácí...",
+  "playerrevive.gui.label.time_left": "Zbývající čas: %s",
+  "playerrevive.gui.hold": "Drž '%s' po dobu %s sekund"
 }

--- a/src/main/resources/assets/playerrevive/lang/en_us.json
+++ b/src/main/resources/assets/playerrevive/lang/en_us.json
@@ -1,8 +1,6 @@
 {
-	"playerrevive.chat.bleeding": "%s is bleeding. %s",
-	"death.attack.bledToDeath.player": "%s bled out",
-	"playerrevive.gui.button.send": "send",
-	"playerrevive.gui.label.time_left": "Time left %s",
-	"playerrevive.gui.hold": "Hold '%s' for %s seconds to give up or get revived",
-	"playerrevive.revive.item": "You require "
+  "playerrevive.chat.bleeding": "%s is bleeding out and may need your help",
+  "playerrevive.gui.label.time_left": "Time left: %s",
+  "playerrevive.gui.hold": "Wait for help or hold '%s' for %s seconds to give up",
+  "playerrevive.revive.item": "You need %s"
 }

--- a/src/main/resources/assets/playerrevive/lang/es_cl.json
+++ b/src/main/resources/assets/playerrevive/lang/es_cl.json
@@ -1,8 +1,6 @@
 {
-	"playerrevive.chat.bleeding": "%s se está desangrando. %s",
-	"death.attack.bledToDeath.player": "%s se desangró",
-	"playerrevive.gui.button.send": "enviar",
-	"playerrevive.gui.label.time_left": "Te desangrarás en %s",
-	"playerrevive.gui.hold": "Mantén '%s' por %s segundos para rendirte",
-	"playerrevive.revive.item": "Necesitas"
+  "playerrevive.chat.bleeding": "%s se está desangrando",
+  "playerrevive.gui.label.time_left": "Te desangrarás en %s",
+  "playerrevive.gui.hold": "Mantén '%s' por %s segundos para rendirte",
+  "playerrevive.revive.item": "Necesitas %s"
 }

--- a/src/main/resources/assets/playerrevive/lang/es_es.json
+++ b/src/main/resources/assets/playerrevive/lang/es_es.json
@@ -1,8 +1,6 @@
 {
-	"playerrevive.chat.bleeding": "%s se está desangrando. %s",
-	"death.attack.bledToDeath.player": "%s se desangró",
-	"playerrevive.gui.button.send": "enviar",
-	"playerrevive.gui.label.time_left": "Te desangrarás en %s",
-	"playerrevive.gui.hold": "Mantén '%s' por %s segundos para rendirte",
-	"playerrevive.revive.item": "Necesitas"
+  "playerrevive.chat.bleeding": "%s se está desangrando",
+  "playerrevive.gui.label.time_left": "Te desangrarás en %s",
+  "playerrevive.gui.hold": "Mantén '%s' por %s segundos para rendirte",
+  "playerrevive.revive.item": "Necesitas %s"
 }

--- a/src/main/resources/assets/playerrevive/lang/es_mx.json
+++ b/src/main/resources/assets/playerrevive/lang/es_mx.json
@@ -1,8 +1,6 @@
 {
-	"playerrevive.chat.bleeding": "%s se está desangrando. %s",
-	"death.attack.bledToDeath.player": "%s se desangró",
-	"playerrevive.gui.button.send": "enviar",
-	"playerrevive.gui.label.time_left": "Te desangrarás en %s",
-	"playerrevive.gui.hold": "Mantén '%s' por %s segundos para rendirte",
-	"playerrevive.revive.item": "Necesitas"
+  "playerrevive.chat.bleeding": "%s se está desangrando",
+  "playerrevive.gui.label.time_left": "Te desangrarás en %s",
+  "playerrevive.gui.hold": "Mantén '%s' por %s segundos para rendirte",
+  "playerrevive.revive.item": "Necesitas %s"
 }

--- a/src/main/resources/assets/playerrevive/lang/ja_jp.json
+++ b/src/main/resources/assets/playerrevive/lang/ja_jp.json
@@ -1,8 +1,6 @@
 {
-	"playerrevive.chat.bleeding": "%sは血を流している. %s",
-	"death.attack.bledToDeath.player": "%sは血を流した",
-	"playerrevive.gui.button.send": "送信",
-	"playerrevive.gui.label.time_left": "残り時間 %s",
-	"playerrevive.gui.hold": "ギブアップもしくは復活するには'%s'をあと%s秒間押し続けてください",
-	"playerrevive.revive.item": "必要なものは "
+  "playerrevive.chat.bleeding": "%sは血を流している",
+  "playerrevive.gui.label.time_left": "残り時間：%s",
+  "playerrevive.gui.hold": "ギブアップもしくは復活するには'%s'をあと%s秒間押し続けてください",
+  "playerrevive.revive.item": "必要なものは%s"
 }

--- a/src/main/resources/assets/playerrevive/lang/no_no.json
+++ b/src/main/resources/assets/playerrevive/lang/no_no.json
@@ -1,7 +1,5 @@
 {
-	"playerrevive.chat.bleeding": "%s blør...",
-	"death.attack.bledToDeath.player": "%s blødde ut",
-	"playerrevive.gui.button.send": "Send",
-	"playerrevive.gui.label.time_left": "Gjennstående tid: %s",
-	"playerrevive.gui.hold": "Hold '%s' i %s sekunder"
+  "playerrevive.chat.bleeding": "%s blør...",
+  "playerrevive.gui.label.time_left": "Gjennstående tid: %s",
+  "playerrevive.gui.hold": "Hold '%s' i %s sekunder"
 }

--- a/src/main/resources/assets/playerrevive/lang/pt_br.json
+++ b/src/main/resources/assets/playerrevive/lang/pt_br.json
@@ -1,8 +1,6 @@
 {
-	"playerrevive.chat.bleeding": "%s está sangrando. %s",
-	"death.attack.bledToDeath.player": "%s sangrou até a morte",
-	"playerrevive.gui.button.send": "send",
-	"playerrevive.gui.label.time_left": "Tempo restante %s",
-	"playerrevive.gui.hold": "Segure o '%s' por %s segundos para desistir"
-	"playerrevive.revive.item": "Voce requer "
+  "playerrevive.chat.bleeding": "%s está sangrando",
+  "playerrevive.gui.label.time_left": "Tempo restante: %s",
+  "playerrevive.gui.hold": "Segure o '%s' por %s segundos para desistir",
+  "playerrevive.revive.item": "Voce requer %s"
 }

--- a/src/main/resources/assets/playerrevive/lang/ru_ru.json
+++ b/src/main/resources/assets/playerrevive/lang/ru_ru.json
@@ -1,8 +1,6 @@
 {
-	"playerrevive.chat.bleeding": "%s истекает кровью. %s",
-	"death.attack.bledToDeath.player": "%s истек кровью",
-	"playerrevive.gui.button.send": "отправить",
-	"playerrevive.gui.label.time_left": "Времени осталось %s",
-	"playerrevive.gui.hold": "Удерживайте '%s' в течении %s секунд",
-	"playerrevive.revive.item": "Вам требуется "
+  "playerrevive.chat.bleeding": "%s истекает кровью",
+  "playerrevive.gui.label.time_left": "Времени осталось: %s",
+  "playerrevive.gui.hold": "Удерживайте '%s' в течении %s секунд",
+  "playerrevive.revive.item": "Вам требуется %s"
 }

--- a/src/main/resources/assets/playerrevive/lang/vi_vn.json
+++ b/src/main/resources/assets/playerrevive/lang/vi_vn.json
@@ -1,8 +1,6 @@
 {
-	"playerrevive.chat.bleeding": "%s đang hấp hối. %s",
-	"death.attack.bledToDeath.player": "%s đã nằm xuống",
-	"playerrevive.gui.button.send": "gửi",
-	"playerrevive.gui.label.time_left": "Thời gian còn lại %s",
-	"playerrevive.gui.hold": "Giữ '%s' trong %s giây",
-	"playerrevive.revive.item": "Bạn cần "
+  "playerrevive.chat.bleeding": "%s đang hấp hối",
+  "playerrevive.gui.label.time_left": "Thời gian còn lại: %s",
+  "playerrevive.gui.hold": "Giữ '%s' trong %s giây",
+  "playerrevive.revive.item": "Bạn cần %s"
 }


### PR DESCRIPTION
This pull request consists of four main parts.

1\. The global chat message that informs other players when someone is injured and bleeding out has been rewritten and now clearly communicates that the player is still alive and can still be helped. Why? Because it seems that this was the original purpose of the message added by this mod (but if not, then the message should only appear after the player dies from blood loss instead). Additionally, the cause of the injury is no longer shown in the message, as it doesn’t make any sense, since [most causes](https://minecraft.wiki/w/Death_messages) clearly indicate that the player is already dead, so why would they need any help? Unless it's from a gravedigger...

2\. In the message that is displayed to a player who is bleeding out, more emphasis has been placed on the fact that they can still be saved if they just wait for help. Why? Because I believe that rescuing your friends from difficult situations is the essence of this mod. That's the primary reason people download this mod, and that's how it is advertised in the trailer. As a consequence, the information about holding a button to give up has been moved to the end of the message.

3\. The name of the item needed to revive an injured player is no longer appended to the rest of the message. Instead, the `%s` format specifier and the two-parameter `Component#translatable()` method are used. This approach gives translators much more freedom and flexibility to create better translations.

4\. All translation files have undergone a general cleanup. The following two translation keys: `playerrevive.gui.button.send` and `death.attack.bledToDeath.player` have been removed, as they haven't been in use for 3 and 1.5 years, respectively. The code associated with the former has been removed in commit d0c2989eb8eb27aec273124fc13ca67302cca4e5, and the code for the latter in commit 522ce0f0ee0d10fd7e31743d25234a9adf2c1309 (if I'm not mistaken). In addition, all translation files now consistently use the LF line endings, and the Brazilian Portuguese translation is once again readable by the game. One of the translators wasn’t careful enough and missed a comma, making the entire translation unusable for almost 2 years.

I'm open to all kinds of criticism and comments because I realize that what seems like a positive change to me, may actually be the opposite. After all, this is your mod and your repository (not mine).