### PR TITLE
fix: prevent black screen on respawn after giving up

### DIFF
--- a/src/main/java/team/creative/playerrevive/client/ReviveEventClient.java
+++ b/src/main/java/team/creative/playerrevive/client/ReviveEventClient.java
@@ -217,7 +217,7 @@ public class ReviveEventClient {
                 
                 addedEffect = true;
                 
-                if (PlayerRevive.CONFIG.bleeding.hasShaderEffect)
+                if (PlayerRevive.CONFIG.bleeding.hasShaderEffect && player.isAlive())
                     mc.gameRenderer.processBlurEffect();
                 
                 if (!mc.options.hideGui && mc.screen == null) {


### PR DESCRIPTION
When a player gave up by holding the attack key, the server immediately called kill() on them. Due to network ordering, the client-side bleeding state was still true for several frames after the server had already initiated the death/respawn level transition. During those frames, processBlurEffect() was being called on GameRenderer while Minecraft's main render target was being torn down and re-initialized, resulting in a black screen after clicking the respawn button.

The fix guards processBlurEffect() with player.isAlive(). The server sets the player's health to 0 before sending the death packet, so isAlive() returns false at exactly the right moment — before the framebuffer transition begins — even if the ReviveUpdatePacket has not yet arrived to clear the client-side bleeding state.

This did not affect natural bleed-out deaths because the server sends ReviveUpdatePacket every 5 ticks throughout the bleed timer, so the client-side bleeding state was already cleared well before death in that path.